### PR TITLE
Electron version of Jeff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ test
 test-output
 npm-debug.log
 node_modules
+.DS_Store

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Jeff</title>
+	</head>
+	<body>
+		
+	</body>
+
+	<script> require('./index.js'); </script>
+</html>

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,92 @@
+var electron    = require('electron');
+var main        = electron.remote.require('./main.js');
+var ipcRenderer = electron.ipcRenderer;
+var jeff        = require('../src/index.js');
+var commander   = require('commander');
+
+
+function executeJeff(argv, cb) {
+
+	commander
+
+	// Primary options
+	.option('-s, --source <src file/glob expression>',      'Source of the file(s) to export. Can be defined as a regular expression', '*.swf')
+	.option('-i, --inputDir <dir>',                         'Input directory, directory must exist', '.')
+	.option('-o, --outDir <dir>',                           'Output directory', '.')
+
+	// Secondary options
+	.option('-S, --scope <scope>',                          'Scope of the animation to export, either \'classes\' or \'main\'', 'main')
+	.option('-r, --ratio <ratio>',                          'Image scale', '1')
+	.option('-f, --renderFrames <boolean/array of frames>', 'To extract specified frames of the animations as PNGs', 'false')
+
+	// Optimisation options
+	.option('-O, --imageOptim <boolean>',                   'To apply a lossless image compression', 'false')
+	.option('-q, --imageQuality <quality>',                 'Image quality. From 0 to 100', '100')
+	.option('-a, --createAtlas <boolean>',                  'To extract all the images of an animation into a single atlas', 'false')
+	.option('-p, --powerOf2Images <boolean>',               'To set the dimensions of output images to powers of 2', 'false')
+	.option('-M, --maxImageDim <number>',                   'Maximum image dimension', '2048')
+	.option('-m, --simplify <boolean>',                     'To simplify animations (reduce number of symbols)', 'false')
+	.option('-b, --beautify <boolean>',                     'To beautify JSON output', 'false')
+	.option('-n, --flatten <boolean>',                      'To extract a flat animation structure rather than a hierarchical structure', 'false')
+	.option('-c, --compressMatrices <boolean>',             'To extract animations with matrices under a compressed format', 'false')
+
+	// Advanced options
+	.option('-R, --exportAtRoot <boolean>',                 'To export everything at the root of the output directory', 'false')
+	.option('-C, --splitClasses <boolean>',                 'To split the different classes of the animation into several outputs', 'false')
+	.option('-d, --ignoreData <boolean>',                   'Not to export JSON meta-data', 'false')
+	.option('-I, --ignoreImages <boolean>',                 'Not to export images', 'false')
+	.option('-F, --filtering <filtering method>',           'Filtering that should be used when rendering the animation', 'linear')
+	.option('-e, --outlineEmphasis <coefficient>',          'Emphasis of outlines when rendering Flash vectorial drawings', '1')
+
+	.parse(argv);
+
+	var exportParams = {
+		// Primary options
+		inputDir:           commander.inputDir,
+		outDir:             commander.outDir || '.', // By default, always writing to disk when JEFF used in command line
+		source:             commander.source,
+
+		// Secondary options
+		scope:              commander.scope,
+		ratio:              JSON.parse(commander.ratio),
+		renderFrames:       JSON.parse(commander.renderFrames),
+
+		// Optimisation options
+		imageOptim:         JSON.parse(commander.imageOptim),
+		imageQuality:       JSON.parse(commander.imageQuality),
+		createAtlas:        JSON.parse(commander.createAtlas),
+		powerOf2Images:     JSON.parse(commander.powerOf2Images),
+		maxImageDim:        JSON.parse(commander.maxImageDim),
+		simplify:           JSON.parse(commander.simplify),
+		beautify:           JSON.parse(commander.beautify),
+		flatten:            JSON.parse(commander.flatten),
+		compressMatrices:   JSON.parse(commander.compressMatrices),
+
+		// Advanced options
+		splitClasses:       JSON.parse(commander.splitClasses),
+		exportAtRoot:       JSON.parse(commander.exportAtRoot),
+		ignoreData:         JSON.parse(commander.ignoreData),
+		ignoreImages:       JSON.parse(commander.ignoreImages),
+		filtering:          commander.filtering,
+		outlineEmphasis:    JSON.parse(commander.outlineEmphasis)
+	};
+
+	// Creating a new Jeff
+	jeff(exportParams, cb);
+}
+
+
+ipcRenderer.on('argv', function (sender, argv) {
+	argv = JSON.parse(argv);
+	var haveArguments = argv.length > 2;
+
+	if (haveArguments) {
+		// execute jeff with provided arguments
+		executeJeff(argv, function onComplete() {
+			// close electron application
+			main.quit();
+		});
+	} else {
+		// TODO: no arguments -> start Jeff in GUI mode
+	}
+});

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/index.js');
+module.exports = require('./src/index.js');

--- a/main.js
+++ b/main.js
@@ -1,0 +1,41 @@
+var path     = require('path');
+var url      = require('url');
+var electron = require('electron');
+
+var app = electron.app;
+var mainWindow = null;
+
+function createWindow () {
+	mainWindow = new electron.BrowserWindow({ width: 600, height: 600 });
+
+	mainWindow.loadURL(url.format({
+		pathname: path.join(__dirname, 'app/index.html'),
+		protocol: 'file:',
+		slashes:  true
+	}));
+
+	mainWindow.webContents.openDevTools();
+
+	mainWindow.webContents.on('did-finish-load', function onReady() {
+		mainWindow.webContents.send('argv', JSON.stringify(process.argv));
+	});
+
+	mainWindow.on('closed', function onClosed() {
+		mainWindow = null;
+	});
+}
+
+exports.quit = function () {
+	app.quit();
+	mainWindow = null;
+}
+
+app.on('ready', createWindow);
+
+app.on('window-all-closed', function () {
+	app.quit();
+});
+
+app.on('activate', function () {
+	if (mainWindow === null) createWindow();
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "jeff",
 	"description": "Extracts Json meta-data and images from a SWF Flash file.",
-	"version": "0.2.4",
+	"version": "0.3.0",
 	"private": false,
 	"author": {
 		"name": "Brice Chevalier",
@@ -10,17 +10,20 @@
 	"bin": {
 		"jeff": "./bin/jeff"
 	},
-	"main": "./src/index.js",
+	"main": "main.js",
+	"scripts": {
+		"start": "electron ."
+	},
 	"dependencies": {
         "async": "0.2.10",
         "buffer-crc32": "^0.2.5",
-        "canvas": "1.1.6",
         "commander": "2.2.0",
         "fs-extra": "0.8.1",
         "glob": "4.3.1",
-        "image-optim": "0.3.0",
-        "js-beautify": "1.4.2",
-        "node-pngquant-native": "0.0.12"
+        "js-beautify": "1.4.2"
+	},
+	"devDependencies": {
+		"electron": "^1.4.1"
 	},
 	"repository": {
 		"type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,8 @@ var glob     = require('glob');
 var path     = require('path');
 var async    = require('async');
 var beautify = require('js-beautify').js_beautify;
-var pngquant = require('node-pngquant-native');
-var imgOptim = require('image-optim');
+// var pngquant = require('node-pngquant-native');
+// var imgOptim = require('image-optim');
 
 var helper         = require('./Helper/index.js');
 var SwfParser      = require('./Gordon/parser.js');
@@ -139,7 +139,7 @@ Jeff.prototype._init = function (options, cb) {
 	this._extractedData = [];
 
 	// Making sure the input directory exists
-	if (!fs.existsSync(this._options.inputDir)) {
+	if (this._options.outDir && !fs.existsSync(this._options.inputDir)) {
 		throw new Error('Directory not found: ' + this._options.inputDir);
 		return;
 	}
@@ -155,7 +155,6 @@ Jeff.prototype._init = function (options, cb) {
 	} else {
 		var self = this;
 		glob(this._options.source, { cwd: this._options.inputDir }, function (error, uris) {
-			console.error('uris', self._options.source, uris)
 			cb(uris);
 		})
 	}
@@ -381,14 +380,16 @@ Jeff.prototype._canvasToPng = function (pngName, canvas) {
 	var png = new Buffer(url.substr(len), 'base64');
 
 	if (this._options.imageQuality < 100) {
-		png = pngquant.compress(png, { quality: [this._options.imageQuality, 100] });
+		// TODO
+		// png = pngquant.compress(png, { quality: [this._options.imageQuality, 100] });
 	}
 
 	if (!this._options.customWriteFile || !this._options.customWriteFile(pngName, png)) {
 		writeFile(pngName, png);
 
 		if (this._options.imageOptim) {
-			imgOptim.optimize(pngName, function() {})
+			// TODO
+			// imgOptim.optimize(pngName, function() {})
 		}
 	}
 };


### PR DESCRIPTION
# What
We needed to remove dependencies to **node-canvas** and other native libraries that are painful to install and made Jeff not portable. We decided to use **Electron** in order to use built-in Chronium's canvas as a replacement to **node-canvas**. 

# To do
 - Make a GUI version of Jeff when no parameters have been provided
 - We need to find an alternative to the **node-png-quant** and **image-optim** libraries.

Some replacement candidates for **png-quant** (to investigate):
 - [rgbquant](https://www.npmjs.com/package/rgbquant)
 - [neuquant-js](https://www.npmjs.com/package/neuquant-js)
 - [optipng](https://github.com/imagemin/imagemin-optipng)
