### PR TITLE
Fixed a bug with empty rectangles parsing

### DIFF
--- a/src/Gordon/stream.js
+++ b/src/Gordon/stream.js
@@ -221,10 +221,7 @@ module.exports = Stream;
 				// Edit: it looks like this hack is making the export fail on some swf
 				// (may be those from the latest flash versions?)
 				// So the bytes need to be tested in order to know whether the hack is necessary
-				var nextByte0 = this._buffer.slice(this.offset, this.offset + 1);
-				var nextByte1 = this._buffer.slice(this.offset, this.offset + 2);
-
-				if (nextByte0 === 0 && nextByte1 === 0) {
+				if (this._buffer.readUInt16LE(this.offset) === 0) {
 					var empty = this.readBytes(16); //console.warn('numBits=1, rect:',rect)
 					for(var i = 0; i < 16; i++) {
 						if(empty[i] !== 0) { throw new Error('Unexpected rectangle data'); }


### PR DESCRIPTION
`nextByte0` and `nextByte1` were both `Buffer` objects, comparing them to an integer is everytime `false`.

Thank you @olombart for the pre-review and code simplification 😄!

Ping @bchevalier @cstoquer.