### PR TITLE
More logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,8 @@ function JeffOptions(params) {
 	this.customWriteFile     = params.customWriteFile;
 	this.customReadFile      = params.customReadFile;
 	this.fixedSize           = params.fixedSize;
+	// 1: minimal log level, 10: maximum log level. TODO: needs to be implemented on every console.warn/log/error
+	this.verbosity           = params.verbosity           || 3;
 
 	// Whether only one frame is being rendered
 	// Boolean used for naming purpose
@@ -212,8 +214,9 @@ Jeff.prototype._parseFileGroup = function (fileGroup, nextGroupCb) {
 };
 
 Jeff.prototype._parseFile = function (swfName, nextSwfCb) {
-	console.log('parsing: ' + swfName);
-
+	if (this._options.verbosity >= 5) {
+		console.log('parsing: ' + swfName);
+	}
 	var self = this;
 	var swfObjects = [];
 	function onFileRead(error, swfData) {

--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,7 @@ Jeff.prototype._parseFileGroup = function (fileGroup, nextGroupCb) {
 };
 
 Jeff.prototype._parseFile = function (swfName, nextSwfCb) {
+	console.log('parsing: ' + swfName);
 
 	var self = this;
 	var swfObjects = [];


### PR DESCRIPTION
When node process crashes during an operation we don't have any information about the file that was currently processed. When it happens during a big batch of files that takes an hour or two to process it's extremely painful to have to add the console log and restart the process from scratch to identify the file who caused it.

Also it adds a better feeling of progression to the user.

In the future we should add a verbosity parameter.

Ping @bchevalier @cstoquer @nullorvoid.