### PR TITLE
Fixed artefacts when using a texture generated with certain options

### DIFF
--- a/src/CanvasRenderer/renderImages.js
+++ b/src/CanvasRenderer/renderImages.js
@@ -2,6 +2,9 @@
 var getCanvas      = require('./GetCanvas');
 var CanvasRenderer = require('./main');
 
+// margin between assets in atlasmaps
+var MARGIN = 1;
+
 CanvasRenderer.prototype._getMaxDimensions = function (graphics) {
 	var graphicsMaxDims = {};
 	var classRatios     = this._options.classRatios || {};
@@ -55,7 +58,6 @@ CanvasRenderer.prototype._getMaxDimensions = function (graphics) {
 	return graphicsMaxDims;
 };
 
-var MARGIN = 1;
 CanvasRenderer.prototype._setGraphicDimensions = function (graphics, graphicMaxDims) {
 
 	var graphicDims = {};
@@ -287,7 +289,7 @@ CanvasRenderer.prototype._renderFrames = function (canvasses, graphicProperties)
 					sx: 0, sy: 0,
 					sw: canvas.width,
 					sh: canvas.height,
-					margin: 0
+					margin: MARGIN
 				};
 			}
 		}


### PR DESCRIPTION
Fixed artefacts/glitches when using a texture generated with both options `createAtlas` and `renderFrames`.

We may want to refactor this in future: do we need a margin option ***per asset*** in an atlas? Common sense would say it should be a unique option for the whole atlasmap. We may also want the user to be able to set this value with other export parameters.