### PR TITLE
Fixed rendering when masked layers have blend modes

### DIFF
--- a/src/CanvasRenderer/swfSymbolRendering.js
+++ b/src/CanvasRenderer/swfSymbolRendering.js
@@ -144,6 +144,9 @@ CanvasRenderer.prototype._renderSymbol = function (globalCanvas, globalContext, 
 				clipCanvas.width  = localCanvas.width;
 				clipCanvas.height = localCanvas.height;
 
+				// To support masked layers with blend mode
+				clipContext.drawImage(localCanvas, 0, 0);
+
 				// Rendering all the children that are meant to be clipped
 				var clipDepth = child.clipDepth;
 				while (!children[--c].maskEnd) {


### PR DESCRIPTION
Fixed rendering when masked layers have blend modes. Previously, masked layers were drawn on a an empty canvas, their blend modes having no effect.

Ping @bchevalier @cstoquer @cainmartin.

- [ ] To do after merge: pull change in Electron's branch.