### PR TITLE
Handling swf headers, fps propagation, dynamic version output

### DIFF
--- a/src/CanvasRenderer/renderImages.js
+++ b/src/CanvasRenderer/renderImages.js
@@ -153,7 +153,8 @@ CanvasRenderer.prototype._setGraphicDimensions = function (graphics, graphicMaxD
 			dx: x * graphicRatio,
 			dy: y * graphicRatio,
 			ratio:  graphicRatio,
-			margin: MARGIN
+			margin: MARGIN,
+			frameRate: graphic.swfObject && graphic.swfObject._frameRate
 		};
 	}
 
@@ -289,7 +290,8 @@ CanvasRenderer.prototype._renderFrames = function (canvasses, graphicProperties)
 					sx: 0, sy: 0,
 					sw: canvas.width,
 					sh: canvas.height,
-					margin: MARGIN
+					margin: MARGIN,
+					frameRate: symbol.swfObject && symbol.swfObject._frameRate
 				};
 			}
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -431,7 +431,7 @@ Jeff.prototype._retrieveFrameRate = function (graphicProperties) {
 		}
 	}
 	return frameRate || fallback;
-}
+};
 
 Jeff.prototype._generateExportData = function (graphicProperties, imageNames) {
 	// Constructing symbols data that will be included in the export

--- a/src/index.js
+++ b/src/index.js
@@ -414,6 +414,7 @@ Jeff.prototype._canvasToPng = function (pngName, canvas) {
 	}
 };
 
+// TODO: frame rate should be stored on symbols instead of graphic properties
 Jeff.prototype._retrieveFrameRate = function (graphicProperties) {
 	var frameRate;
 	var fallback = this._options.fallbackFrameRate;


### PR DESCRIPTION
- SWF headers are now handled.
- Exported JSON now respects original files framerate when it's possible (resolves https://github.com/Wizcorp/Jeff/issues/31).
- Exported JSON's version is now dynamic.

Ping @bchevalier @dyoxyne @cstoquer @cainmartin.