### PR TITLE
Added export functionality for mp3's

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ jeff(options, function (error, stats, extractedData) {
 * Will sequentially parse and process the SWF files.
 * Will export JSON meta-data and images corresponding to the SWF files.
 
+For a list of command line options:
+
+```shell
+jeff -h
+```
+
 ### Roadmap for unsupported features
 
 * Texts (Static/Dynamic)
@@ -98,4 +104,4 @@ jeff(options, function (error, stats, extractedData) {
 * Option to extract shapes under vectorial format
 * Option to extract meta-data under keyframe based format (as opposed to per frame transformation matrix)
 
-For contributors, see [SWF File Format Specifications](http://wwwimages.adobe.com/www.adobe.com/content/dam/Adobe/en/devnet/swf/pdf/swf-file-format-spec.pdf)
+For contributors, see [SWF File Format Specifications](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf)

--- a/bin/jeff
+++ b/bin/jeff
@@ -36,6 +36,8 @@ program
 .option('-I, --ignoreImages <boolean>',                 'Not to export images', 'false')
 .option('-F, --filtering <filtering method>',           'Filtering that should be used when rendering the animation', 'linear')
 .option('-e, --outlineEmphasis <coefficient>',          'Emphasis of outlines when rendering Flash vectorial drawings', '1')
+.option('-V, --version <int>', 			 		        'If specified, force decompiler to attempt to decompile as if the swf was specified version', '-1')
+.option('-L, --verbosity <int>', 			 			'(L)og Level. 1-10, 1 showing least, 10 showing the most. Default is 3', '3')
 
 .parse(process.argv);
 
@@ -67,7 +69,9 @@ var exportParams = {
 	ignoreData:         JSON.parse(program.ignoreData),
 	ignoreImages:       JSON.parse(program.ignoreImages),
 	filtering:          program.filtering,
-	outlineEmphasis:    JSON.parse(program.outlineEmphasis)
+	outlineEmphasis:    JSON.parse(program.outlineEmphasis),
+	forceVersion: 		JSON.parse(program.version),
+	verbosity:   		JSON.parse(program.verbosity)
 };
 
 // Creating a new Jeff

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "jeff",
 	"description": "Extracts Json meta-data and images from a SWF Flash file.",
-	"version": "0.2.10",
+	"version": "0.3.0",
 	"private": false,
 	"author": {
 		"name": "Brice Chevalier",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
 	"dependencies": {
         "async": "0.2.10",
         "buffer-crc32": "^0.2.5",
-        "canvas": "1.1.6",
+        "canvas": "1.6.11",
         "commander": "2.2.0",
         "fs-extra": "0.8.1",
         "glob": "4.3.1",
         "image-optim": "0.3.0",
         "js-beautify": "1.4.2",
-        "node-pngquant-native": "0.0.12"
+        "node-pngquant-native": "2.0.1"
 	},
 	"repository": {
 		"type": "git",

--- a/src/Gordon/base.js
+++ b/src/Gordon/base.js
@@ -17,7 +17,8 @@ var Base = {
 	},
 	validSignatures: {
 		SWF: 'FWS',
-		COMPRESSED_SWF: 'CWS'
+		COMPRESSED_ZLIB_SWF: 'CWS',
+		COMPRESSED_LZMA_SWF: 'ZWS'
 	},
 	readyStates: {
 		LOADING: 0,

--- a/src/Gordon/base.js
+++ b/src/Gordon/base.js
@@ -304,6 +304,22 @@ var Base = {
 		13: 'overlay',
 		14: 'hardlight'
 	},
+	soundFormats: {
+		UNCOMPRESSED_NATIVE_ENDIAN: 0,		//swf 1
+		ADPCM: 1,							//swf 1
+		MP3: 2,								//swf 4
+		UNCOMPRESSED_LITTLE_ENDIAN: 3, 		//swf 4
+		NELLYMOSER16KHZ: 4, 				//swf 10
+		NELLYMOSER8KHZ: 5, 					//swf 10
+		NELLYMOSER: 6, 						//swf 6
+		SPEEX: 11 							//swf 10
+	},
+	soundRates: {
+		0: 5500,
+		1: 11000,
+		2: 22000,
+		3: 44000
+	}
 };
 
 (function () {

--- a/src/Gordon/stream.js
+++ b/src/Gordon/stream.js
@@ -3,10 +3,12 @@
 
 var zlib = require('zlib');
 
-function Stream(data){
+function Stream(data, options){
 	this._buffer = new Buffer(data);
 	this._nBytes = data.length;
 	this.offset  = 0;
+
+	this._options = options;
 
 	this._bitBuffer  = null;
 	this._bitOffset  = 8;
@@ -217,14 +219,17 @@ module.exports = Stream;
 				// We simply skip this useless zeros here, but verify it was actually zeros we skipped.
 				// If one day we find something else than an all zero rect (e.g. a 0,0,1,1) we will
 				// have to adapt some more here...
-
+				
 				// Edit: it looks like this hack is making the export fail on some swf
 				// (may be those from the latest flash versions?)
 				// So the bytes need to be tested in order to know whether the hack is necessary
-				if (this._buffer.readUInt16LE(this.offset) === 0) {
-					var empty = this.readBytes(16); //console.warn('numBits=1, rect:',rect)
-					for(var i = 0; i < 16; i++) {
-						if(empty[i] !== 0) { throw new Error('Unexpected rectangle data'); }
+				if(this._options.version < 30)//Not exactly sure which version makes this work/break
+				{
+					if (this._buffer.readUInt16LE(this.offset) === 0) {
+						var empty = this.readBytes(16); //console.warn('numBits=1, rect:',rect)
+						for(var i = 0; i < 16; i++) {
+							if(empty[i] !== 0) { throw new Error('Unexpected rectangle data'); }
+						}
 					}
 				}
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -229,29 +229,30 @@ Jeff.prototype._parseFileGroup = function (fileGroup, nextGroupCb) {
 
 Jeff.prototype._parseFile = function (swfName, nextSwfCb) {
 	if (this._options.verbosity >= 5) {
-		console.log('parsing: ' + swfName);
+		console.log('=================================');//to quickly find the start in a wall of text
+		console.log('Parsing: ' + swfName);
+		console.log('=================================');
 	}
 	var self = this;
 	var swfObjects = [];
 	function onFileRead(error, swfData) {
 		if (error) return nextSwfCb(error);
 		self._parser.parse(swfName, swfData, self._options,
-			function (swfObject) {
+			function (swfObject) {//include a .info on the object if you want to display more information
 				var id = swfObject.id;
 				swfObject._swfName = swfName;
 				
 				if(self._options.verbosity > 5)
 				{
-
-					console.log('parsing: ' + swfName);
-					
-					//console.log('object', JSON.stringify(swfObject));
-					console.log('');
-					console.log('--Object-- ');
+					console.log('\n--Object-- ');
 					console.log('Id', swfObject.id);
 					console.log('Type', swfObject.type);
-					for (var p in swfObject) {
-						console.log(p);
+					//for (var p in swfObject) {
+						//console.log(p);
+					//}
+					//console.log('object', JSON.stringify(swfObject));
+					if(swfObject.info != null) {
+						console.log(util.inspect(swfObject.info));
 					}
 				}
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* jshint camelcase: false */ //for js_beautify and indent_size
 'use strict';
+var util   	 = require('util');
 
 var fs       = require('fs-extra');
 var glob     = require('glob');
@@ -20,6 +21,11 @@ var JSON_WRITE_OPTIONS = { encoding:'binary' };
 
 // Jeff's only API method
 function extractSwf(exportParams, cb) {
+	
+	if(exportParams.verbosity > 8){
+		console.log('Options: '+util.inspect(exportParams));
+	}
+
 	var jeff = new Jeff();
 
 	// Setting up Jeff ...
@@ -104,6 +110,8 @@ function JeffOptions(params) {
 	this.customWriteFile     = params.customWriteFile;
 	this.customReadFile      = params.customReadFile;
 	this.fixedSize           = params.fixedSize;
+	this.forceVersion 		 = params.forceVersion;
+	this.version 			 = params.version;
 	this.fallbackFrameRate   = params.fallbackFrameRate   || 25;
 	// 1: minimal log level, 10: maximum log level. TODO: needs to be implemented on every console.warn/log/error
 	this.verbosity           = params.verbosity           || 3;
@@ -227,15 +235,26 @@ Jeff.prototype._parseFile = function (swfName, nextSwfCb) {
 	var swfObjects = [];
 	function onFileRead(error, swfData) {
 		if (error) return nextSwfCb(error);
-		self._parser.parse(swfName, swfData,
+		self._parser.parse(swfName, swfData, self._options,
 			function (swfObject) {
 				var id = swfObject.id;
 				swfObject._swfName = swfName;
-				// console.log('object', JSON.stringify(swfObject));
-				// console.log('properties!!', swfObject.id);
-				// for (var p in swfObject) {
-				// 	console.log(p);
-				// }
+				
+				if(self._options.verbosity > 5)
+				{
+
+					console.log('parsing: ' + swfName);
+					
+					//console.log('object', JSON.stringify(swfObject));
+					console.log('');
+					console.log('--Object-- ');
+					console.log('Id', swfObject.id);
+					console.log('Type', swfObject.type);
+					for (var p in swfObject) {
+						console.log(p);
+					}
+				}
+
 				if (id === undefined) {
 
 					if (swfObject.type === 'scalingGrid') {

--- a/src/index.js
+++ b/src/index.js
@@ -356,6 +356,11 @@ Jeff.prototype._extractClassGroup = function (imageList, graphicProperties, next
 		if (!this._options.ignoreData) {
 			this._writeDataToDisk(data);
 		}
+		for (var i = 0; i < this._parser.dataStorage.length; i += 1) {
+			
+			writeFile(this._fileGroupName + this._parser.dataStorage[i].fileName, this._parser.dataStorage[i].bytes);
+		}
+
 	}
 
 	if (this._options.returnData) {


### PR DESCRIPTION
Based on feature request https://github.com/Wizcorp/Jeff/issues/4, I've gone ahead and made the base system for exporting audio. My test use cases included 4 SWF files I found from quite a few years ago, each a different use case of the SWF format. The ones with sound used MP3's, so I was unable to test the other formats, but more than likely they would be very similar to the MP3 way. Just a binary data dump onto the harddrive. But without a way to test easily I left those for another day.

A side effect is that all binaries also get exported now, and may be hard for users to know how to handle.